### PR TITLE
Fixed invalid bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -14,7 +14,7 @@
   ],
   "main": [
   	"jquery.viewloader.js",
-  	"jquery.viewloader.min.js",
+  	"jquery.viewloader.min.js"
   ],
   "keywords": [
   	"view",


### PR DESCRIPTION
Hey, i just found out the **bower.json** didn't pass jsonlint. I fixed little typo and it's now fine again.

I'm guy behind [VersionEye](https://www.versioneye.com/) and we are currently working on integration of bower packages and doing some initial analysis on the quality of bower packages. That's how i found that bug;
